### PR TITLE
Lowercase file format

### DIFF
--- a/src/imagetransforms/SharpImageTransform.php
+++ b/src/imagetransforms/SharpImageTransform.php
@@ -114,7 +114,7 @@ class SharpImageTransform extends ImageTransform
                     $transform->format = 'jpeg';
                 }
             }
-            $format = $transform->format;
+            $format = strtolower($transform->format);
             $format = self::TRANSFORM_FORMATS[$format] ?? $format;
             // param: quality
             $edits[$format]['quality'] = (int)($transform->quality ?? 100);


### PR DESCRIPTION
Forcing the file format to lowercase will ensure an image named "image.JPG" still translates to a "jpeg" transformation. It just makes the determination a bit more flexible.