### PR TITLE
Fix the preg_match for the x- and y positions

### DIFF
--- a/src/imagetransforms/SharpImageTransform.php
+++ b/src/imagetransforms/SharpImageTransform.php
@@ -165,7 +165,7 @@ class SharpImageTransform extends ImageTransform
                 $position = $xPos.'-'.$yPos;
             }
             if (!empty($position)) {
-                if (preg_match('/(top|center|bottom)-(left|center|right)/', $position)) {
+                if (preg_match('/(left|center|right)-(top|center|bottom)/', $position)) {
                     $positions = explode('-', $position);
                     $positions = array_diff($positions, ['center']);
                     if (!empty($positions) && $position !== 'center-center') {


### PR DESCRIPTION
The fix for #2 (aa07b9a) didn't update the `preg_match` resulting in no focalpoint information being added to the Sharp transform config. 