### PR TITLE
Fixed an issue with corrupted images throwing an exception

### DIFF
--- a/src/imagetransforms/SharpImageTransform.php
+++ b/src/imagetransforms/SharpImageTransform.php
@@ -181,7 +181,7 @@ class SharpImageTransform extends ImageTransform
             $mode = $edits['resize']['fit'];
             $edits['resize']['fit'] = self::TRANSFORM_MODES[$mode] ?? $mode ?? 'cover';
             // Handle auto-sharpening
-            if ($settings->autoSharpenScaledImages) {
+            if ($settings->autoSharpenScaledImages && $asset->getWidth() && $asset->getHeight()) {
                 // See if the image has been scaled >= 50%
                 $widthScale = (int)((($transform->width ?? $asset->getWidth()) / $asset->getWidth()) * 100);
                 $heightScale =  (int)((($transform->height ?? $asset->getHeight()) / $asset->getHeight()) * 100);


### PR DESCRIPTION
Related issue: https://github.com/nystudio107/craft-imageoptimize-sharp/issues/6

Same bug with [https://github.com/nystudio107/craft-imageoptimize-imgix](craft-imageoptimize-imgix) package: https://github.com/nystudio107/craft-imageoptimize-imgix/issues/3

This PR is basically the same bug fix that was done to the other transformer.