### PR TITLE
Fix default focal point v4

### DIFF
--- a/src/imagetransforms/SharpImageTransform.php
+++ b/src/imagetransforms/SharpImageTransform.php
@@ -141,7 +141,7 @@ class SharpImageTransform extends ImageTransform
             }
             // Handle the focal point
             $position = $transform->position;
-            $focalPoint = $asset->getFocalPoint();
+            $focalPoint = $asset->getHasFocalPoint() ? $asset->getFocalPoint() : false;
             if (!empty($focalPoint)) {
                 if ($focalPoint['x'] < 0.33) {
                     $xPos = 'left';

--- a/src/imagetransforms/SharpImageTransform.php
+++ b/src/imagetransforms/SharpImageTransform.php
@@ -157,7 +157,7 @@ class SharpImageTransform extends ImageTransform
                 } else {
                     $yPos = 'bottom';
                 }
-                $position = $xPos . '-' . $yPos;
+                $position = $yPos . '-' . $xPos;
             }
             if (!empty($position) && preg_match('/(top|center|bottom)-(left|center|right)/', $position)) {
                 $positions = explode('-', $position);

--- a/src/imagetransforms/SharpImageTransform.php
+++ b/src/imagetransforms/SharpImageTransform.php
@@ -159,9 +159,11 @@ class SharpImageTransform extends ImageTransform
                 }
                 $position = $xPos . '-' . $yPos;
             }
-            if (!empty($position) && preg_match('/(left|center|right)-(top|center|bottom)/', $position)) {
+            if (!empty($position) && preg_match('/(top|center|bottom)-(left|center|right)/', $position)) {
                 $positions = explode('-', $position);
                 $positions = array_diff($positions, ['center']);
+                // Reverse the coordinates because Sharp requires them in the "X Y" format
+                $positions = array_reverse($positions);
                 if (!empty($positions) && $position !== 'center-center') {
                     $edits['resize']['position'] = implode(' ', $positions);
                 }


### PR DESCRIPTION
### Description
Firstly, I fixed the check for the focal point
`            $focalPoint = $asset->getHasFocalPoint() ? $asset->getFocalPoint() : false;`
Secondly, I corrected the coordinates along the axes.
Craft will give us the coordinates in `Y-X` format, while Sharp requires it in `X Y` format, or just `Y` if the `X` is in the `center`. So I added `array_reverse` for it.

Here's a video proving it works:
https://github.com/nystudio107/craft-imageoptimize-sharp/assets/3519951/65b0febf-453c-4266-9a1f-944006fe08d1


### Related issues
https://github.com/nystudio107/craft-imageoptimize-sharp/issues/8